### PR TITLE
Implement fetching and saving CSVs

### DIFF
--- a/download.py
+++ b/download.py
@@ -72,44 +72,47 @@ def download(user_id, date_ranges=[]):
     br.follow_link(export_link)
 
     for (from_date, to_date) in date_ranges:
-        print br.title()
-        br.select_form(name='frmTest')
-        # "Date range" as opposed to "Current view of statement"
-        br['frmTest:rdoDateRange'] = ['1']
+        download_range(br, from_date, to_date)
 
-        def setDate(field_name, date):
-            br[field_name] = [date.strftime('%d')]
-            br[field_name + '.month'] = [date.strftime('%m')]
-            br[field_name + '.year'] = [date.strftime('%Y')]
+def download_range(br, from_date, to_date):
+    print br.title()
+    br.select_form(name='frmTest')
+    # "Date range" as opposed to "Current view of statement"
+    br['frmTest:rdoDateRange'] = ['1']
 
-        setDate('frmTest:dtSearchFromDate', from_date)
-        setDate('frmTest:dtSearchToDate', to_date)
+    def setDate(field_name, date):
+        br[field_name] = [date.strftime('%d')]
+        br[field_name + '.month'] = [date.strftime('%m')]
+        br[field_name + '.year'] = [date.strftime('%Y')]
 
-        response = br.submit()
-        info = response.info()
+    setDate('frmTest:dtSearchFromDate', from_date)
+    setDate('frmTest:dtSearchToDate', to_date)
 
-        if info.gettype() != 'application/csv':
-            print response
-            raise Exception('Did not get a CSV back (maybe there are more than 150 transactions?)')
+    response = br.submit()
+    info = response.info()
 
-        disposition = info.getheader('Content-Disposition')
-        PREFIX='attachment; filename='
-        if disposition.startswith(PREFIX):
-            suggested_prefix, ext = os.path.splitext(disposition[len(PREFIX):])
-            filename = '{0} {1:%Y-%m-%d} {2:%Y-%m-%d}{3}'.format(
-                suggested_prefix, from_date, to_date, ext)
+    if info.gettype() != 'application/csv':
+        print response
+        raise Exception('Did not get a CSV back (maybe there are more than 150 transactions?)')
 
-            with open(filename, 'a') as f:
-                for line in response:
-                    f.write(line)
+    disposition = info.getheader('Content-Disposition')
+    PREFIX='attachment; filename='
+    if disposition.startswith(PREFIX):
+        suggested_prefix, ext = os.path.splitext(disposition[len(PREFIX):])
+        filename = '{0} {1:%Y-%m-%d} {2:%Y-%m-%d}{3}'.format(
+            suggested_prefix, from_date, to_date, ext)
 
-            print "Saved transactions to '%s'" % filename
+        with open(filename, 'a') as f:
+            for line in response:
+                f.write(line)
 
-        else:
-            print response
-            raise Exception('Missing "Content-Disposition: attachment" header')
+        print "Saved transactions to '%s'" % filename
 
-        br.back()
+    else:
+        print response
+        raise Exception('Missing "Content-Disposition: attachment" header')
+
+    br.back()
 
 def parse_date(string):
     try:

--- a/download.py
+++ b/download.py
@@ -3,6 +3,8 @@
 Outputs a CSV, pipe it somewhere or something.
 """
 
+import argparse
+import datetime
 import getpass
 import mechanize
 
@@ -18,7 +20,7 @@ def extract(data, before, after):
     end   = data.index(after, start)
     return data[start:end]
 
-def download():
+def download(user_id, from_date, to_date):
     # a new browser and open the login page
     br = mechanize.Browser()
     br.set_handle_robots(False)
@@ -28,7 +30,7 @@ def download():
     while 'Enter Memorable Information' not in title:
         print br.title()
         br.select_form(name='frmLogin')
-        br['frmLogin:strCustomerLogin_userID'] = prompt("Enter user ID:")
+        br['frmLogin:strCustomerLogin_userID'] = str(user_id)
         br['frmLogin:strCustomerLogin_pwd']    = prompt("Enter password:", True)
         response = br.submit() # attempt log-in
         title    = br.title()
@@ -73,21 +75,30 @@ def download():
     # "Date range" as opposed to "Current view of statement"
     br['frmTest:rdoDateRange'] = ['1']
 
-    yyyy, mm, dd = prompt("Enter start date (YYYY/MM/DD): ").split('/', 2)
-    br['frmTest:dtSearchFromDate'] = [yyyy]
-    br['frmTest:dtSearchFromDate.month'] = [mm]
-    br['frmTest:dtSearchFromDate.year'] = [dd]
+    def setDate(field_name, date):
+        br[field_name] = [date.strftime('%d')]
+        br[field_name + '.month'] = [date.strftime('%m')]
+        br[field_name + '.year'] = [date.strftime('%Y')]
 
-    yyyy, mm, dd = prompt("Enter end date (YYYY/MM/DD): ").split('/', 2)
-    br['frmTest:dtSearchToDate'] = [yyyy]
-    br['frmTest:dtSearchToDate.month'] = [mm]
-    br['frmTest:dtSearchToDate.year'] = [dd]
+    setDate('frmTest:dtSearchFromDate', from_date)
+    setDate('frmTest:dtSearchToDate', to_date)
 
     response = br.submit()
     print response.read()
 
-def main():
-    download()
+def parse_date(string):
+    try:
+        yyyy, mm, dd = string.split('/', 2)
+        return datetime.date(int(yyyy), int(mm), int(dd))
+    except ValueError:
+        raise argparse.ArgumentTypeError(
+            "'%s' is not a valid date in the form YYYY/MM/DD" % string)
 
 if __name__=='__main__':
-    main()
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-u', '--user-id', type=int, required=True)
+    parser.add_argument('-f', '--from', type=parse_date, metavar='YYYY/MM/DD', required=True)
+    parser.add_argument('-t', '--to',   type=parse_date, metavar='YYYY/MM/DD', required=True)
+    args = parser.parse_args()
+
+    download(user_id=args.user_id, from_date=getattr(args, 'from'), to_date=args.to)

--- a/download.py
+++ b/download.py
@@ -56,12 +56,35 @@ def download():
             links.append(link)
 
     # allow user to choose one
-    print "Please select an account:"
+    print "Accounts:"
     for i in range(len(links)):
         print "{0}:".format(i), links[i].text.split('[')[0]
-    
-    # export this detail
-    
+
+    n = prompt("Please select an account:")
+    link = links[int(n)]
+    response = br.follow_link(link)
+
+    print br.title()
+    export_link = br.find_link(text='Export')
+    br.follow_link(export_link)
+
+    print br.title()
+    br.select_form(name='frmTest')
+    # "Date range" as opposed to "Current view of statement"
+    br['frmTest:rdoDateRange'] = ['1']
+
+    yyyy, mm, dd = prompt("Enter start date (YYYY/MM/DD): ").split('/', 2)
+    br['frmTest:dtSearchFromDate'] = [yyyy]
+    br['frmTest:dtSearchFromDate.month'] = [mm]
+    br['frmTest:dtSearchFromDate.year'] = [dd]
+
+    yyyy, mm, dd = prompt("Enter end date (YYYY/MM/DD): ").split('/', 2)
+    br['frmTest:dtSearchToDate'] = [yyyy]
+    br['frmTest:dtSearchToDate.month'] = [mm]
+    br['frmTest:dtSearchToDate.year'] = [dd]
+
+    response = br.submit()
+    print response.read()
 
 def main():
     download()


### PR DESCRIPTION
Hi,

I was really pleased to find that someone had already done the bulk of the work on this! This branch let me fetch a bunch of CSVs by running:

```
python download.py -u MY_LLOYDS_TSB_ID 2011/01/01--2011/03/31 2010/10/01--2010/12/31 2010/07/01--2010/09/30
```

This is not very robust or well-tested (and I note that urllib2 and hence mechanize do not check SSL certificates! Danger!) but it does work for me. It would obviously be better to automate breaking down the range into smaller chunks until there are less than 150 transactions, but … this was good enough for me today!
